### PR TITLE
Disable cmd-new/split-window via environment

### DIFF
--- a/cmd-new-window.c
+++ b/cmd-new-window.c
@@ -63,6 +63,11 @@ cmd_new_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct environ_entry	*envent;
 	struct cmd_find_state	 fs;
 
+    if (getenv("CMD_NEW_WINDOW_DISABLED") != NULL) {
+		cmdq_error(item, "disabled");
+        return (CMD_RETURN_ERROR);
+    }
+
 	if (args_has(args, 'a') && wl != NULL) {
 		if ((idx = winlink_shuffle_up(s, wl)) == -1) {
 			cmdq_error(item, "no free window indexes");

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -69,6 +69,11 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct environ_entry	*envent;
 	struct cmd_find_state    fs;
 
+    if (getenv("CMD_SPLIT_WINDOW_DISABLED") != NULL) {
+        cmdq_error(item, "disabled");
+        return (CMD_RETURN_ERROR);
+    }
+
 	server_unzoom_window(w);
 
 	if (args->argc == 0) {


### PR DESCRIPTION
For example,
CMD_NEW_WINDOW_DISABLED=1 CMD_SPLIT_WINDOW_DISABLED=1 ./tmux ...
will disable these two commands